### PR TITLE
Git-Server für WiringPi ist offline

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -365,7 +365,7 @@ pi@raspberry:~$ sudo apt-get install git git-core
 ```   
 Jetzt kann WiringPi heruntergeladen   
 ```
-pi@raspberry:~$ git clone git://git.drogon.net/wiringPi
+pi@raspberry:~$ git clone https://github.com/WiringPi/WiringPi
 pi@raspberry:~$ cd wiringPi
 ```
 und installiert werden:   


### PR DESCRIPTION
git.drogon.net antwortet nicht mehr
Es gibt einen Inoffiziellen Mirror mit der letzten Version: https://github.com/WiringPi/WiringPi